### PR TITLE
Disable faulthandler plugin in pytest configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ dist/*
 
 # Research Dist
 researchNotes/*
+
+.idea/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
           - >
             source ~/miniconda3/etc/profile.d/conda.sh &&
             conda activate MacroSim &&
-            pytest tests &&
+            pytest -p no:faulthandler tests &&
             mypy macrosim/ &&
             conda env export -n MacroSim --no-builds | grep -v "^prefix: " > ./dev/conda_env.yaml &&
             git diff --quiet ./dev/conda_env.yaml || git add ./dev/conda_env.yaml

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 pythonpath = .
 filterwarnings =
     ignore:datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning
+addopts = "-p no:faulthandler"


### PR DESCRIPTION
Added 'addopts = "-p no:faulthandler"' to pytest.ini to prevent the faulthandler plugin from being loaded during test runs.